### PR TITLE
add getByDefaultName and common exports to metro

### DIFF
--- a/src/core-plugins/CommandHandler.ts
+++ b/src/core-plugins/CommandHandler.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommand, Commands, CommandSection } from "../api/Commands";
+import { ApplicationCommand, ApplicationCommandType, Commands, CommandSection } from "../api/Commands";
 import { Plugin } from "../entities/Plugin";
 import { getByProps } from "../metro";
 import { after } from "../utils/patcher";
@@ -7,7 +7,7 @@ export default class CommandHandler extends Plugin {
     start() {
         const commands = getByProps("getBuiltInCommands");
         after<any, ApplicationCommand[], any>(commands, "getBuiltInCommands", context => {
-            if (context.args[0] !== 1) return;
+            if (context.args[0] != ApplicationCommandType.CHAT) return;
             context.result = [...context.result, ...Commands._commands];
         });
 

--- a/src/core-plugins/CommandHandler.ts
+++ b/src/core-plugins/CommandHandler.ts
@@ -6,14 +6,15 @@ import { after } from "../utils/patcher";
 export default class CommandHandler extends Plugin {
     start() {
         const commands = getByProps("getBuiltInCommands");
-        after<any, ApplicationCommand[], any>(commands, "getBuiltInCommands", context => [...context.result, ...Commands._commands]);
+        after<any, ApplicationCommand[], any>(commands, "getBuiltInCommands", context => {
+            if (context.args[0] !== 1) return;
+            context.result = [...context.result, ...Commands._commands];
+        });
 
         const discovery = getByProps("useApplicationCommandsDiscoveryState");
         after(discovery, "useApplicationCommandsDiscoveryState", context => {
-            const shouldDisplay = context.args[3] === false;
-
             const res = context.result as any;
-            if (shouldDisplay && !res.discoverySections.find((s: any) => s.key === Commands._aliucordSection.id) && Commands._commands.length) {
+            if (!res.discoverySections.find((s: any) => s.key === Commands._aliucordSection.id) && Commands._commands.length) {
                 res.discoveryCommands.push(...Commands._commands);
                 res.commands.push(...Commands._commands.filter(
                     command => !res.commands.some((cmd: ApplicationCommand) => cmd.name === command.name))
@@ -29,7 +30,7 @@ export default class CommandHandler extends Plugin {
                 offsets.push(offsets[offsets.length - 1] + commands.BUILT_IN_COMMANDS.length - 1);
             }
 
-            if (shouldDisplay && !res.applicationCommandSections.find((s: CommandSection) => s.id === Commands._aliucordSection.id) && Commands._commands.length) {
+            if (!res.applicationCommandSections.find((s: CommandSection) => s.id === Commands._aliucordSection.id) && Commands._commands.length) {
                 res.applicationCommandSections.push(Commands._aliucordSection);
             }
         });

--- a/src/core-plugins/NoTrack.ts
+++ b/src/core-plugins/NoTrack.ts
@@ -27,8 +27,11 @@ export default class NoTrack extends Plugin {
         hub.getScope().clear();
 
         const c = console as any;
-        for (const method in c) if (c[method].__sentry_original__) {
-            c[method] = c[method].__sentry_original__;
+        for (const method in c) {
+            if (c[method].__sentry_original__)
+                c[method] = c[method].__sentry_original__;
+            if (c[method].__REACT_DEVTOOLS_ORIGINAL_METHOD__?.__sentry_original__)
+                c[method].__REACT_DEVTOOLS_ORIGINAL_METHOD__ = c[method].__REACT_DEVTOOLS_ORIGINAL_METHOD__.__sentry_original__;
         }
     }
 }

--- a/src/metro/index.ts
+++ b/src/metro/index.ts
@@ -122,6 +122,14 @@ export function getByDisplayName(displayName: string, options?: FilterOptions) {
 }
 
 /**
+ * Find a module by its default.name property. Usually useful for finding React Components
+ * @returns Module if found, else null
+ */
+export function getByDefaultName(defaultName: string, options?: FilterOptions) {
+    return getModule(m => m?.default?.name === defaultName, options);
+}
+
+/**
  * Find a Store by its name. 
  * @returns Module if found, else null
  */
@@ -251,6 +259,33 @@ export const ContextMenuActions = getByProps("openContextMenu");
 export const Clipboard = getByProps("getString", "setString") as {
     getString(): Promise<string>,
     setString(str: string): Promise<void>;
+};
+
+export const Dialog = getByProps("show", "openLazy", "open", "close") as {
+    show(options: {
+        title?: string,
+        body?: string,
+        confirmText?: string,
+        cancelText?: string,
+        confirmColor?: string,
+        isDismissable?: boolean,
+        onConfirm?: () => any,
+        onCancel?: () => any;
+    });
+    close();
+};
+
+export const Toasts = getModule(m => (
+    m.open !== undefined && m.close !== undefined && !m.openLazy && !m.startDrag && !m.init && !m.openReplay
+)) as {
+    open(options: {
+        content?: string,
+        /**
+         * Specify toast icon AssetId, specify by using getAssetId()
+         */
+        source?: number;
+    });
+    close();
 };
 
 export const RestAPI = getByProps("getAPIBaseURL", "get");

--- a/src/metro/index.ts
+++ b/src/metro/index.ts
@@ -125,7 +125,7 @@ export function getByDisplayName(displayName: string, options?: FilterOptions) {
  * Find a module by its default.name property. Usually useful for finding React Components
  * @returns Module if found, else null
  */
-export function getByDefaultName(defaultName: string, options?: FilterOptions) {
+export function getByName(defaultName: string, options?: FilterOptions) {
     return getModule(m => m?.default?.name === defaultName, options);
 }
 
@@ -270,9 +270,11 @@ export const Dialog = getByProps("show", "openLazy", "open", "close") as {
         confirmColor?: string,
         isDismissable?: boolean,
         onConfirm?: () => any,
-        onCancel?: () => any;
-    });
-    close();
+        onCancel?: () => any,
+        [k: PropertyKey]: any;
+    }),
+    close(),
+    [k: PropertyKey]: any;
 };
 
 export const Toasts = getModule(m => (
@@ -283,9 +285,11 @@ export const Toasts = getModule(m => (
         /**
          * Specify toast icon AssetId, specify by using getAssetId()
          */
-        source?: number;
-    });
-    close();
+        source?: number,
+        [k: PropertyKey]: any;
+    }),
+    close(),
+    [k: PropertyKey]: any;
 };
 
 export const RestAPI = getByProps("getAPIBaseURL", "get");

--- a/src/ui/patchSettings.tsx
+++ b/src/ui/patchSettings.tsx
@@ -1,5 +1,5 @@
 import { sha } from "aliucord-version";
-import { Forms, getByDefaultName, i18n, React, ReactNative as RN } from "../metro";
+import { Forms, getByName, i18n, React, ReactNative as RN } from "../metro";
 import { after } from "../utils/patcher";
 import AliucordPage from "./AliucordPage";
 import PluginsPage from "./PluginsPage";
@@ -8,9 +8,9 @@ import UpdaterPage from "./UpdaterPage";
 
 export default function patchSettings() {
     const { FormSection, FormRow } = Forms;
-    const UserSettingsOverviewWrapper = getByDefaultName("UserSettingsOverviewWrapper");
+    const UserSettingsOverviewWrapper = getByName("UserSettingsOverviewWrapper");
 
-    after(getByDefaultName("getScreens"), "default", (_, res) => {
+    after(getByName("getScreens"), "default", (_, res) => {
         res.ASettings = {
             title: "Aliucord",
             render: AliucordPage

--- a/src/ui/patchSettings.tsx
+++ b/src/ui/patchSettings.tsx
@@ -1,5 +1,5 @@
 import { sha } from "aliucord-version";
-import { Forms, getModule, i18n, React, ReactNative as RN } from "../metro";
+import { Forms, getByDefaultName, i18n, React, ReactNative as RN } from "../metro";
 import { after } from "../utils/patcher";
 import AliucordPage from "./AliucordPage";
 import PluginsPage from "./PluginsPage";
@@ -8,9 +8,9 @@ import UpdaterPage from "./UpdaterPage";
 
 export default function patchSettings() {
     const { FormSection, FormRow } = Forms;
-    const UserSettingsOverviewWrapper = getModule(m => m.default?.name === "UserSettingsOverviewWrapper");
+    const UserSettingsOverviewWrapper = getByDefaultName("UserSettingsOverviewWrapper");
 
-    after(getModule(m => m.default?.name === "getScreens"), "default", (_, res) => {
+    after(getByDefaultName("getScreens"), "default", (_, res) => {
         res.ASettings = {
             title: "Aliucord",
             render: AliucordPage

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,7 @@
 import { externalStorageDirectory } from "../native/fs";
 
 export const ALIUCORD_INVITE = "https://discord.gg/EsNDvBaHVU";
-export const ALIUCORD_GITHUB = "https://github.com/Aliucord/Aliucord";
+export const ALIUCORD_GITHUB = "https://github.com/Aliucord/AliucordRN";
 export const ALIUCORD_PATREON = "https://patreon.com/Aliucord";
 
 export const ALIUCORD_DIRECTORY = externalStorageDirectory + "/AliucordRN/";


### PR DESCRIPTION
- adds `getByName` to metro to as it is very useful in finding components
- adds `Dialog` and `Toasts` to metro
- fix the wrong github repository url in constants
- fix commands showing where they shouldnt once more