### PR TITLE
Make plugins be enabled by default

### DIFF
--- a/src/api/PluginManager.ts
+++ b/src/api/PluginManager.ts
@@ -43,7 +43,7 @@ export async function startPlugins() {
                 zip.closeEntry();
 
                 if (manifest.name in plugins) throw new Error(`Plugin ${manifest.name} already registered`);
-                if (!isPluginEnabled(manifest.name)) continue;
+                if (isPluginEnabled(manifest.name)) continue;
 
                 zip.openEntry("index.js.bundle");
                 const pluginBuffer = zip.readEntry("binary");

--- a/src/api/PluginManager.ts
+++ b/src/api/PluginManager.ts
@@ -13,7 +13,8 @@ const logger = new Logger("PluginManager");
 export const plugins = {} as Record<string, Plugin>;
 
 export function isPluginEnabled(plugin: string) {
-    return window.Aliucord.settings.get("plugins", {})[plugin] === true;
+    const pluginEntry = window.Aliucord.settings.get("plugins", {})[plugin];
+    return pluginEntry === undefined ? true : window.Aliucord.settings.get("plugins", {})[plugin] === true;
 }
 
 export function enablePlugin(plugin: string) {
@@ -43,7 +44,7 @@ export async function startPlugins() {
                 zip.closeEntry();
 
                 if (manifest.name in plugins) throw new Error(`Plugin ${manifest.name} already registered`);
-                if (isPluginEnabled(manifest.name)) continue;
+                if (!isPluginEnabled(manifest.name)) continue;
 
                 zip.openEntry("index.js.bundle");
                 const pluginBuffer = zip.readEntry("binary");

--- a/src/api/PluginManager.ts
+++ b/src/api/PluginManager.ts
@@ -14,7 +14,7 @@ export const plugins = {} as Record<string, Plugin>;
 
 export function isPluginEnabled(plugin: string) {
     const pluginEntry = window.Aliucord.settings.get("plugins", {})[plugin];
-    return pluginEntry === undefined ? true : window.Aliucord.settings.get("plugins", {})[plugin] === true;
+    return pluginEntry === undefined ? true : pluginEntry === true;
 }
 
 export function enablePlugin(plugin: string) {

--- a/src/api/PluginManager.ts
+++ b/src/api/PluginManager.ts
@@ -13,8 +13,7 @@ const logger = new Logger("PluginManager");
 export const plugins = {} as Record<string, Plugin>;
 
 export function isPluginEnabled(plugin: string) {
-    const pluginEntry = window.Aliucord.settings.get("plugins", {})[plugin];
-    return pluginEntry === undefined ? true : pluginEntry === true;
+    return window.Aliucord.settings.get("plugins", {})[plugin] !== false;
 }
 
 export function enablePlugin(plugin: string) {


### PR DESCRIPTION
Another way would be to check if pluginEntry is undefined and then call enablePlugin, not sure which would be the preferred way.