### PR TITLE
fix stupit return if .zip not at end of file

### DIFF
--- a/src/api/PluginManager.ts
+++ b/src/api/PluginManager.ts
@@ -45,7 +45,7 @@ export async function disablePlugin(plugin: string) {
 
 export async function startPlugins() {
     for (const file of readdir(PLUGINS_DIRECTORY)) {
-        if (!file.name.endsWith(".zip")) return;
+        if (!file.name.endsWith(".zip")) continue;
 
         const plugin = await loadPlugin(file.name);
         if (!plugin) continue;


### PR DESCRIPTION
fixes plugins not being loaded because if any file doesnt end with .zip, it'll stop the loop