### PR TITLE
fix: apply theme on start

### DIFF
--- a/src/Aliucord.ts
+++ b/src/Aliucord.ts
@@ -2,6 +2,7 @@ import { startCorePlugins, startPlugins } from "./api/PluginManager";
 import { Settings } from "./api/Settings";
 import { mkdir } from "./native/fs";
 import patchSettings from "./ui/patchSettings";
+import patchTheme from "./ui/patchTheme";
 import { PLUGINS_DIRECTORY, SETTINGS_DIRECTORY, THEME_DIRECTORY } from "./utils/constants";
 import { startDebugWs } from "./utils/debug/DebugWS";
 import { startReactDevTools } from "./utils/debug/ReactDevTools";
@@ -12,6 +13,7 @@ interface SettingsSchema {
     autoUpdatePlugins: boolean;
     disablePluginsOnCrash: boolean;
     plugins: Record<string, boolean>;
+    enableAMOLEDTheme: boolean;
 }
 
 export * as pluginManager from "./api/PluginManager";
@@ -33,6 +35,7 @@ export async function load() {
 
         settings = new Settings("Aliucord");
         patchSettings();
+        patchTheme();
 
         await startCorePlugins();
         await startPlugins();

--- a/src/metro/index.ts
+++ b/src/metro/index.ts
@@ -250,6 +250,7 @@ export function searchByKeyword(keyword: string, skipConstants = true) {
 
 export const UserStore = getByStoreName("UserStore");
 export const GuildStore = getByStoreName("GuildStore");
+export const ThemeStore = getByStoreName("ThemeStore");
 export const ChannelStore = getByStoreName("ChannelStore");
 export const MessageStore = getByStoreName("MessageStore");
 export const GuildMemberStore = getByStoreName("GuildMemberStore");
@@ -262,6 +263,7 @@ export const FetchUserActions = getByProps("fetchProfile");
 export const ContextMenuActions = getByProps("openContextMenu");
 export const SnowflakeUtils = getByProps("fromTimestamp", "extractTimestamp");
 export const Locale = getByProps("Messages");
+export const AMOLEDThemeManager = getByProps("setAMOLEDThemeEnabled");
 
 export const Clipboard = getByProps("getString", "setString") as {
     getString(): Promise<string>,
@@ -304,6 +306,7 @@ export const Constants = getByProps("Fonts") as import("./constants").default;
 export const URLOpener = getByProps("openURL", "handleSupportedURL");
 export const Forms = getByProps("FormSection");
 export const Scenes = getByName("getScreens", { default: false });
+export const ThemeManager = getByProps("updateTheme", "overrideTheme");
 
 // Abandon all hope, ye who enter here
 type Style = ViewStyle & ImageStyle & TextStyle;

--- a/src/ui/patchTheme.ts
+++ b/src/ui/patchTheme.ts
@@ -1,0 +1,40 @@
+import { logger } from "../Aliucord";
+import { AMOLEDThemeManager, FluxDispatcher, ThemeManager, ThemeStore } from "../metro";
+import { patcher } from "../utils";
+
+export default function patchTheme() {
+    logger.info("Patching theme...");
+
+    try {
+        // Can't figure out where the AMOLED theme toggle is stored, so we'll just store it in Aliucord's settings
+        if (AMOLEDThemeManager) {
+            if (window.Aliucord.settings.get("enableAMOLEDTheme", false)) {
+                AMOLEDThemeManager.enableAMOLEDThemeOption();
+                logger.info("Enabled AMOLED theme");
+            }
+
+            patcher.before(AMOLEDThemeManager, "setAMOLEDThemeEnabled", (_, enabled) => {
+                logger.info(`Setting AMOLED theme to ${enabled}`);
+                window.Aliucord.settings.set("enableAMOLEDTheme", enabled);
+            });
+        } else {
+            logger.error("Could not get AMOLEDThemeManager");
+        }
+
+        // 'I18N_LOAD_START' dispatch is the best time I can find to override the theme without breaking it.
+        // Therefore, there's no guarantee that this will fix it for everyone
+        if (ThemeStore) {
+            const overrideTheme = () => {
+                ThemeManager.overrideTheme(ThemeStore.theme ?? "dark");
+                logger.info(`Overrode theme to ${ThemeStore.theme ?? "dark"}`);
+                FluxDispatcher.unsubscribe("I18N_LOAD_START", overrideTheme);
+            };
+            
+            FluxDispatcher.subscribe("I18N_LOAD_START", overrideTheme);
+        } else {
+            logger.error("Could not get ThemeStore");
+        }
+    } catch (err) {
+        logger.error("Failed to patch theme", err);
+    }
+}


### PR DESCRIPTION
AliucordRN has somehow caused theming in Discord to break. As fix, we can apply the theme manually during the app start-up.

This pull request closes issue #39.