### PR TITLE
patchTheme: Use AMOLED State instead

### DIFF
--- a/src/Aliucord.ts
+++ b/src/Aliucord.ts
@@ -1,5 +1,6 @@
 import { startCorePlugins, startPlugins } from "./api/PluginManager";
 import { Settings } from "./api/Settings";
+import { themerInit } from "./api/Themer";
 import { mkdir } from "./native/fs";
 import patchSettings from "./ui/patchSettings";
 import patchTheme from "./ui/patchTheme";
@@ -37,6 +38,7 @@ export async function load() {
         patchSettings();
         patchTheme();
 
+        themerInit();
         await startCorePlugins();
         await startPlugins();
         startReactDevTools();

--- a/src/api/Themer.ts
+++ b/src/api/Themer.ts
@@ -1,0 +1,47 @@
+import { Theme } from "../entities";
+import { Constants, getByName, AMOLEDThemeManager } from "../metro";
+import { readdir } from "../native/fs";
+import { Logger } from "../utils";
+import { THEME_DIRECTORY } from "../utils/constants";
+import { after } from "../utils/patcher";
+
+const logger = new Logger("Themer");
+
+export function themerInit() {
+
+    // Only those two are used
+    AliuHermes.unfreeze(Constants.ThemeColorMap);
+    AliuHermes.unfreeze(Constants.Colors);
+
+    for (const file of readdir(THEME_DIRECTORY)) {
+        if (!file.name.endsWith(".json")) continue;
+
+        const themeFile = JSON.parse(AliuFS.readFile(THEME_DIRECTORY + file.name, "text") as string) as Theme;
+
+        for (const key in Constants.ThemeColorMap) {
+            Constants.ThemeColorMap[key][2] = Constants.ThemeColorMap[key][0];
+            if (themeFile.theme_color_map[key]) {
+                Constants.ThemeColorMap[key][2] = themeFile.theme_color_map[key]?.[0];
+                Constants.ThemeColorMap[key][1] = themeFile.theme_color_map[key]?.[1];
+
+                logger.info("Patched theme color", key);
+            }
+        }
+
+        for (const key in themeFile.colors) {
+            Constants.Colors[key] = themeFile.colors[key];
+        }
+
+        // Chat Box
+        after(getByName("ChatInput").default.prototype, "render", (_, comp) => {
+            comp.props.children[2].props.children.props.style[0].backgroundColor = themeFile.theme_color_map["BACKGROUND_SECONDARY"][1];
+        });
+
+        // Navigation Bar
+        after(getByName("ChannelSafeAreaBottom"), "default", (_, comp) => {
+            comp.props.style.backgroundColor = themeFile.theme_color_map["BACKGROUND_SECONDARY"][1];
+        });
+
+        AMOLEDThemeManager.enableAMOLEDThemeOption();
+    }
+} 

--- a/src/entities/types.ts
+++ b/src/entities/types.ts
@@ -9,3 +9,11 @@ export interface PluginAuthor {
     id: string;
     name: string;
 }
+
+export type Theme = {
+    name: string;
+    description: string;
+    version: string;
+    theme_color_map: string[];
+    colors: string[];
+}

--- a/src/metro/index.ts
+++ b/src/metro/index.ts
@@ -255,6 +255,7 @@ export const ChannelStore = getByStoreName("ChannelStore");
 export const MessageStore = getByStoreName("MessageStore");
 export const GuildMemberStore = getByStoreName("GuildMemberStore");
 export const SelectedChannelStore = getByStoreName("SelectedChannelStore");
+export const UnsyncedUserSettingsStore = getByStoreName("UnsyncedUserSettingsStore");
 
 export const ModalActions = getByProps("closeModal");
 export const MessageActions = getByProps("sendMessage", "receiveMessage");

--- a/src/ui/patchTheme.ts
+++ b/src/ui/patchTheme.ts
@@ -1,35 +1,26 @@
 import { logger } from "../Aliucord";
-import { AMOLEDThemeManager, FluxDispatcher, ThemeManager, ThemeStore } from "../metro";
-import { patcher } from "../utils";
+import { AMOLEDThemeManager, FluxDispatcher, ThemeManager, ThemeStore, UnsyncedUserSettingsStore } from "../metro";
 
 export default function patchTheme() {
     logger.info("Patching theme...");
 
     try {
-        // Can't figure out where the AMOLED theme toggle is stored, so we'll just store it in Aliucord's settings
-        if (AMOLEDThemeManager) {
-            if (window.Aliucord.settings.get("enableAMOLEDTheme", false)) {
-                AMOLEDThemeManager.enableAMOLEDThemeOption();
-                logger.info("Enabled AMOLED theme");
-            }
-
-            patcher.before(AMOLEDThemeManager, "setAMOLEDThemeEnabled", (_, enabled) => {
-                logger.info(`Setting AMOLED theme to ${enabled}`);
-                window.Aliucord.settings.set("enableAMOLEDTheme", enabled);
-            });
-        } else {
-            logger.error("Could not get AMOLEDThemeManager");
-        }
-
         // 'I18N_LOAD_START' dispatch is the best time I can find to override the theme without breaking it.
         // Therefore, there's no guarantee that this will fix it for everyone
         if (ThemeStore) {
             const overrideTheme = () => {
                 ThemeManager.overrideTheme(ThemeStore.theme ?? "dark");
                 logger.info(`Overrode theme to ${ThemeStore.theme ?? "dark"}`);
+
+                if (AMOLEDThemeManager) {
+                    if (UnsyncedUserSettingsStore.useAMOLEDTheme === 2) {
+                        AMOLEDThemeManager.enableAMOLEDThemeOption();
+                        logger.info("Enabled AMOLED theme");
+                    }
+                }
                 FluxDispatcher.unsubscribe("I18N_LOAD_START", overrideTheme);
             };
-            
+
             FluxDispatcher.subscribe("I18N_LOAD_START", overrideTheme);
         } else {
             logger.error("Could not get ThemeStore");


### PR DESCRIPTION
* Use Discord's AMOLED State instead of relying on Aliucord's settings